### PR TITLE
Tests speedup

### DIFF
--- a/tests/functional/src/test_cache.py
+++ b/tests/functional/src/test_cache.py
@@ -8,7 +8,7 @@ from tests.functional.settings import test_settings
 pytestmark = pytest.mark.asyncio
 
 
-async def test_shows_show_id_cache(aiohttp_get, es_async_client, es_with_fresh_indexes) -> None:
+async def test_shows_show_id_cache(aiohttp_get, es_async_client, restore_indexes_after) -> None:
     show_id = '00af52ec-9345-4d66-adbe-50eb917f463a'
     endpoint = f'shows/{show_id}'
 
@@ -23,7 +23,7 @@ async def test_shows_show_id_cache(aiohttp_get, es_async_client, es_with_fresh_i
     assert response.body['id'] == show_id
 
 
-async def test_persons_cache_pass(aiohttp_get, es_async_client, es_with_fresh_indexes) -> None:
+async def test_persons_cache_pass(aiohttp_get, es_async_client, restore_indexes_after) -> None:
     person_id = '6e429cff-c8a2-4d17-8b12-6532a8a1ac9b'
     endpoint = f'persons/{person_id}'
     response = await aiohttp_get(endpoint)
@@ -35,7 +35,7 @@ async def test_persons_cache_pass(aiohttp_get, es_async_client, es_with_fresh_in
     assert response.body['id'] == person_id
 
 
-async def test_genres_cache_pass(aiohttp_get, es_async_client, es_with_fresh_indexes) -> None:
+async def test_genres_cache_pass(aiohttp_get, es_async_client, restore_indexes_after) -> None:
     genre_id = '526769d7-df18-4661-9aa6-49ed24e9dfd8'
     endpoint = f'genres/{genre_id}'
     response = await aiohttp_get(endpoint)
@@ -48,7 +48,7 @@ async def test_genres_cache_pass(aiohttp_get, es_async_client, es_with_fresh_ind
 
 
 async def test_persons_cache_expiration(
-        aiohttp_get, es_async_client, es_with_fresh_indexes
+        aiohttp_get, es_async_client, restore_indexes_after
 ) -> None:
     person_id = '6e429cff-c8a2-4d17-8b12-6532a8a1ac9b'
     endpoint = f'persons/{person_id}'
@@ -64,7 +64,7 @@ async def test_persons_cache_expiration(
 
 
 async def test_genres_cache_expiration(
-        aiohttp_get, es_async_client, es_with_fresh_indexes
+        aiohttp_get, es_async_client, restore_indexes_after
 ) -> None:
     genre_id = '5373d043-3f41-4ea8-9947-4b746c601bbd'
     endpoint = f'genres/{genre_id}'

--- a/tests/functional/src/test_genres.py
+++ b/tests/functional/src/test_genres.py
@@ -7,7 +7,7 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_get_all_genres(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_get_all_genres(aiohttp_get) -> None:
     response = await aiohttp_get('genres')
     assert response.status == HTTPStatus.OK
     assert len(response.body) == 10
@@ -21,13 +21,13 @@ async def test_get_all_genres(aiohttp_get, es_with_fresh_indexes) -> None:
         None
      ]
 )
-async def test_genres_non_existing(genre_id, aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_genres_non_existing(genre_id, aiohttp_get) -> None:
     endpoint = f'genres/{genre_id}'
     response = await aiohttp_get(endpoint)
     assert response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_search_genre_from_es_and_api(aiohttp_get, es_with_fresh_indexes, es_client) -> None:
+async def test_search_genre_from_es_and_api(aiohttp_get, es_client) -> None:
     data = es_client.search(index='genres')
     for genre in random.sample(data['hits']['hits'], 10):
         genre_name = genre['_source']['name']

--- a/tests/functional/src/test_persons.py
+++ b/tests/functional/src/test_persons.py
@@ -7,7 +7,7 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_get_all_persons(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_get_all_persons(aiohttp_get) -> None:
     response = await aiohttp_get('persons')
     assert response.status == HTTPStatus.OK
     assert len(response.body) == 10
@@ -21,13 +21,13 @@ async def test_get_all_persons(aiohttp_get, es_with_fresh_indexes) -> None:
         None
      ]
 )
-async def test_persons_non_existing(person_id, aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_persons_non_existing(person_id, aiohttp_get) -> None:
     endpoint = f'persons/{person_id}'
     response = await aiohttp_get(endpoint)
     assert response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_check_persons_on_different_page_size(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_check_persons_on_different_page_size(aiohttp_get) -> None:
     endpoint = 'persons'
     page_size = 16
     query_data = {
@@ -45,7 +45,7 @@ async def test_check_persons_on_different_page_size(aiohttp_get, es_with_fresh_i
     assert person_on_first_page not in response.body
 
 
-async def test_search_person(aiohttp_get, es_with_fresh_indexes, es_client) -> None:
+async def test_search_person(aiohttp_get, es_client) -> None:
     data = es_client.search(index='persons')
     for person in random.sample(data['hits']['hits'], 10):
         person_name = person['_source']['full_name']

--- a/tests/functional/src/test_search.py
+++ b/tests/functional/src/test_search.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.asyncio
         ('genres', pytest.strange_unicode_str, 0, None),
      ]
 )
-async def test_search_endpoints(endpoint, search_query, num_results, first_result_id, aiohttp_get, es_with_fresh_indexes):
+async def test_search_endpoints(endpoint, search_query, num_results, first_result_id, aiohttp_get):
     endpoint = f'{endpoint}/search'
     query_data = {'page[size]': 100}
     if search_query:

--- a/tests/functional/src/test_shows.py
+++ b/tests/functional/src/test_shows.py
@@ -6,14 +6,14 @@ import pytest
 pytestmark = pytest.mark.asyncio
 
 
-async def test_shows_root(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_shows_root(aiohttp_get) -> None:
     endpoint = 'shows'
     response = await aiohttp_get(endpoint)
     assert response.status == HTTPStatus.OK
     assert len(response.body) == 10
 
 
-async def test_shows_get_concrete_show(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_shows_get_concrete_show(aiohttp_get) -> None:
     show_id = '00af52ec-9345-4d66-adbe-50eb917f463a'
     endpoint = f'shows/{show_id}'
     response = await aiohttp_get(endpoint)
@@ -21,14 +21,14 @@ async def test_shows_get_concrete_show(aiohttp_get, es_with_fresh_indexes) -> No
     assert response.body['id'] == show_id
 
 
-async def test_shows_non_existing(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_shows_non_existing(aiohttp_get) -> None:
     show_id = 'not-existent-id'
     endpoint = f'shows/{show_id}'
     response = await aiohttp_get(endpoint)
     assert response.status == HTTPStatus.NOT_FOUND
 
 
-async def test_shows_pagination(aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_shows_pagination(aiohttp_get) -> None:
     endpoint = 'shows'
     page_size = 16
     query_data = {
@@ -79,7 +79,7 @@ async def test_shows_pagination(aiohttp_get, es_with_fresh_indexes) -> None:
         ('Tom', '-imdb_rating', 5, 5, HTTPStatus.OK),
      ]
 )
-async def test_shows_params_validation(query, sort, page_size, page_number, response_status, aiohttp_get, es_with_fresh_indexes) -> None:
+async def test_shows_params_validation(query, sort, page_size, page_number, response_status, aiohttp_get) -> None:
     endpoint = 'shows'
     query_data = {}
     if query is not None:


### PR DESCRIPTION
5x test speedup by not restoring indexes in tests that don't destroy them.